### PR TITLE
PHPStan installed and some minor issues addressed

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,5 @@
+.gitignore
+composer.json
+composer.lock
+phpstan.neon
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+composer.lock
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,39 @@
+{
+  "name": "lenasterg/ls-media-storage-info-multisite",
+  "description": "LS Media Storage Info for Multisite",
+  "type": "wordpress-plugin",
+  "license": "GPL-2.0-or-later",
+  "require": {
+    "php": ">=7.4",
+    "composer/installers": "~2.3.0"
+  },
+  "require-dev": {
+    "phpstan/phpstan": "^1.11",
+    "szepeviktor/phpstan-wordpress": "^1.3",
+    "phpstan/extension-installer": "^1.3"
+  },
+  "scripts": {
+    "phpstan": "@php -d memory_limit=4G vendor/bin/phpstan analyze"
+  },
+  "authors": [
+    {
+      "name": "Lena Stergatou",
+      "email": "lenasterg@chat.wordpress.org",
+      "homepage": "https://lenasterg.wordpress.com"
+    }
+  ],
+  "keywords": [
+    "media",
+    "storage",
+    "multisite",
+    "dashboard",
+    "space"
+  ],
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "phpstan/extension-installer": true
+    }
+  }
+}
+

--- a/ls-media-storage-info-multisite.php
+++ b/ls-media-storage-info-multisite.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return void
  */
-function ls_display_notice_storage_info_multisite() {
+function ls_display_notice_storage_info_multisite(): void {
 
 	echo '<div class="notice notice-info is-dismissible">';
 	ls_display_storage_info_multisite();
@@ -29,12 +29,12 @@ function ls_display_notice_storage_info_multisite() {
  *
  * @return void
  */
-function ls_display_storage_info_multisite() {
+function ls_display_storage_info_multisite(): void {
 	// Get used and available space
 	$quota = get_space_allowed();
 	$used  = get_space_used();
 	if ( $used > $quota ) {
-		$percentused = '100';
+		$percentused = 100;
 	} else {
 		$percentused = ( $used / $quota ) * 100;
 	}
@@ -65,7 +65,7 @@ function ls_display_storage_info_multisite() {
 
 add_action( 'init', 'ls_media_storage_info_multisite_load_textdomain' );
 
-function ls_media_storage_info_multisite_load_textdomain() {
+function ls_media_storage_info_multisite_load_textdomain(): void {
 	load_plugin_textdomain( 'ls-media-storage-info-multisite', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' ); 
 }
 
@@ -75,11 +75,11 @@ function ls_media_storage_info_multisite_load_textdomain() {
  * @param string $hook_suffix The page hook name
  * @return void
  */
-function ls_show_storage_info_on_media_page( $hook_suffix ) {
+function ls_show_storage_info_on_media_page( $hook_suffix ): void {
 	// Check if it's a multisite
 	if ( ! is_multisite() || ! current_user_can( 'upload_files' ) || get_site_option( 'upload_space_check_disabled' )
 	) {
-		return true;
+		return;
 	} else {
 		if ( ( 'media-new.php' === $hook_suffix ) || ( 'upload.php' === $hook_suffix ) ) { // Media Library page
 			add_action( 'admin_notices', 'ls_display_notice_storage_info_multisite' );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 9
+    paths:
+        - ls-media-storage-info-multisite.php
+    excludePaths:
+        - vendor


### PR DESCRIPTION
I just added [PHPStan](https://phpstan.org/) to a [Composer](https://getcomposer.org/) config file so you can install it with `composer install` and run the static code analysis with `composer phpstan`.

I, also, prepared `.gitignore` and `.distignore` files that are used by various Github actions when it comes to build and to deploy.
